### PR TITLE
Fix another faulty span intersection scenario.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,21 +33,21 @@ modifiers = [
 
 text = 'Alexander G. Bell ate 10 apples & 8 cucumbers. The 1st apple was rotten, the 2nd was too, also the third, fourth etc.'
         
-text_processed, span_map = process(text, modifiers)
+processed_text, span_map = process(text, modifiers)
 
-text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+decorated_text, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
 print (text)
-print (text_decorated)
-print (text_processed_decorated)
-print (text_processed)
+print (decorated_text)
+print (processed_text)
+print (decorated_processed_text)
 print (span_map)
 ```
 
 ```bash
 Alexander G. Bell ate 10 apples & 8 cucumbers. The 1st apple was rotten, the 2nd was too, also the third, fourth etc.
 Alexander 00 Bell ate 11 apples 2 3 cucumbers. The 455 apple was rotten, the 677 was too, also the third, fourth 888.
-Alexander 000000 Bell ate 111 apples 222 33333 cucumbers. The 44444 apple was rotten, the 666666 was too, also the third, fourth 888888888.
 Alexander Graham Bell ate ten apples and eight cucumbers. The first apple was rotten, the second was too, also the third, fourth et cetera.
+Alexander 000000 Bell ate 111 apples 222 33333 cucumbers. The 44444 apple was rotten, the 666666 was too, also the third, fourth 888888888.
 [((10, 12), (10, 16)), ((22, 24), (26, 29)), ((32, 33), (37, 40)), ((34, 35), (41, 46)), ((51, 52), (62, 67)), ((52, 54), (67, 67)), ((77, 78), (90, 96)), ((78, 80), (96, 96)), ((113, 116), (129, 138))]
 ```

--- a/re_map/core.py
+++ b/re_map/core.py
@@ -106,10 +106,11 @@ def insert(entry, replacement_span_map):
 
         merge_entries = [replacement_span_map[i] for i in intersecting]
 
+        aligned_entry_target_span = (entry[1][0], entry[1][1] - entry[2])
         for e in merge_entries:
             entry_source_length -= span_length(intersect(e[0], entry[0]))
-            aligned_entry_target_span = (entry[1][0], entry[1][1] - entry[2])
-            entry_target_length -= span_length(intersect(e[1], aligned_entry_target_span))
+            target_intersection = intersect(e[1], aligned_entry_target_span)
+            entry_target_length -= span_length(target_intersection) if target_intersection else 0
             source_length += span_length(e[0])
             target_length += span_length(e[1])
             source_span_start = min(source_span_start, e[0][0])

--- a/re_map/core.py
+++ b/re_map/core.py
@@ -22,7 +22,7 @@ def span_offset(span, replacement_span_map):
         else:
             target_trimmed_start = span_rtrim(span_target, span[0])
             target_trimmed_end = span_rtrim(span_target, span[1])
-            
+
             if target_trimmed_end:
                 # int() and 1.0 multipliers for 2.7 compatibility
                 ratio_end = 1.0 * span_length(target_trimmed_end) / span_length(span_target)
@@ -91,8 +91,8 @@ def insert(entry, replacement_span_map):
     i = 0
     for i, (source_span, target_span, _) in enumerate(replacement_span_map):
         if (
-            (source_span[0] >= entry[0][1] or source_span[0] >= entry[0][0]) or 
-            (target_span[0] >= entry[1][1] or target_span[0] >= entry[1][0]) or 
+            (source_span[0] >= entry[0][1] or source_span[0] >= entry[0][0]) or
+            (target_span[0] >= entry[1][1] or target_span[0] >= entry[1][0]) or
             (intersect(source_span, entry[0])) or
             (intersect(target_span, entry[1]))
             ):

--- a/re_map/core.py
+++ b/re_map/core.py
@@ -7,15 +7,17 @@ __extended__ = False
 def span_len_delta(span_1, span_2):
     return (span_1[1] - span_1[0]) - (span_2[1] - span_2[0])
 
+# TODO: Rewrite, too complicated
 def span_offset(span, replacement_span_map):
     delta_start, delta_end = 0, 0
-    for a in replacement_span_map:
-        span_source, span_target, _ = a
-        if span_target[1] <= span[1]:
+    for span_source, span_target, _ in replacement_span_map:
+        if span[1] >= span_target[1]:
             d = span_len_delta(span_target, span_source)
             delta_end += d
-            if span_target[1] <= span[0]:
+            if span[0] >= span_target[1] or (span[0] - d >= span_target[0]):
                 delta_start += d
+        else:
+            break
 
     return delta_start, delta_end
 
@@ -142,6 +144,8 @@ def clean_replacement_span_map(replacement_span_map):
 def repl(match, replacement_map, replacement_span_map):
     match_string = match.group()
     match_start = match.span(0)[0]
+    if len(match.regs) == 1:
+        raise Exception('No match groups in regex pattern.')
     delta = span_offset(match.span(1), replacement_span_map)
 
     current_match_delta = 0

--- a/re_map/utils.py
+++ b/re_map/utils.py
@@ -5,7 +5,7 @@ def decorate(text, text_modified, span_map):
         span = span_map[i]
         a = span[0][1] - span[0][0]
         b = span[1][1] - span[1][0]
-        v = '{:x}'.format(i).upper()
+        v = '{:x}'.format(i%16).upper()
         text = text[0:span[0][0]] + a*v + text[span[0][1]:]
         text_modified = text_modified[0:span[1][0]] + b*v + text_modified[span[1][1]:]
 

--- a/tests/test_bundled_modifiers.py
+++ b/tests/test_bundled_modifiers.py
@@ -12,14 +12,14 @@ class BundledModifierTestCase(TestCase):
             ( r'(B)',  { 1: 'D'} )
         ]
 
-        text_processed, span_map = process(text, modifiers)
-        self.assertEqual( text_processed, 'CCDCCD' )
+        processed_text, span_map = process(text, modifiers)
+        self.assertEqual( processed_text, 'CCDCCD' )
         self.assertEqual( span_map, [((0, 1), (0, 2)), ((1, 2), (2, 3)), ((2, 3), (3, 5)), ((3, 4), (5, 6))] )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        decorated_text, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
-        self.assertEqual( text_decorated, '0123' )
-        self.assertEqual( text_processed_decorated, '001223' )
+        self.assertEqual( decorated_text, '0123' )
+        self.assertEqual( decorated_processed_text, '001223' )
 
     def test_b(self):
         text = 'AABAAB'
@@ -28,14 +28,14 @@ class BundledModifierTestCase(TestCase):
             ( r'(B)',  { 1:'D'} )
         ]
 
-        text_processed, span_map = process(text, modifiers)
-        self.assertEqual( text_processed, 'CDCD' )
+        processed_text, span_map = process(text, modifiers)
+        self.assertEqual( processed_text, 'CDCD' )
         self.assertEqual( span_map, [((0, 2), (0, 1)), ((2, 3), (1, 2)), ((3, 5), (2, 3)), ((5, 6), (3, 4))] )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        decorated_text, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
-        self.assertEqual( text_decorated, '001223' )
-        self.assertEqual( text_processed_decorated, '0123' )
+        self.assertEqual( decorated_text, '001223' )
+        self.assertEqual( decorated_processed_text, '0123' )
 
     def test_c(self):
         text = 'ABBABB'
@@ -44,14 +44,31 @@ class BundledModifierTestCase(TestCase):
             ( r'(BB)',  { 1:'D'} )
         ]
 
-        text_processed, span_map = process(text, modifiers)
-        self.assertEqual( text_processed, 'CCDCCD' )
+        processed_text, span_map = process(text, modifiers)
+        self.assertEqual( processed_text, 'CCDCCD' )
         self.assertEqual( span_map, [((0, 1), (0, 2)), ((1, 3), (2, 3)), ((3, 4), (3, 5)), ((4, 6), (5, 6))] )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        decorated_text, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
-        self.assertEqual( text_decorated, '011233' )
-        self.assertEqual( text_processed_decorated, '001223' )
+        self.assertEqual( decorated_text, '011233' )
+        self.assertEqual( decorated_processed_text, '001223' )
+
+    def test_empty(self):
+        text = 'BAAB'
+
+        modifiers = [
+            ( r'(AA)',  { 1: 'CC'} ),
+            ( r'(B)',  { 1:''} )
+        ]
+
+        processed_text, span_map = process(text, modifiers)
+        self.assertEqual( processed_text, 'CC' )
+        self.assertEqual( span_map, [((0, 1), (0, 0)), ((1, 3), (0, 2)), ((3, 4), (2, 2))] )
+
+        decorated_text, decorated_processed_text = utils.decorate(text, processed_text, span_map)
+
+        self.assertEqual( decorated_text, '0112' )
+        self.assertEqual( decorated_processed_text, '11' )
 
 if __name__ == '__main__':
     main()

--- a/tests/test_chain_modifiers.py
+++ b/tests/test_chain_modifiers.py
@@ -7,6 +7,8 @@ from re_map import process, core, utils
 core.__verbose__ = True
 
 class ChainModifierTestCase(TestCase):
+    def runTest(self):
+        self.test_chain_1()
     ''' 
     Tests perfect matching match group replacements.
     '''

--- a/tests/test_chain_modifiers.py
+++ b/tests/test_chain_modifiers.py
@@ -25,15 +25,15 @@ class ChainModifierTestCase(TestCase):
             ((13, 16), (13, 16))
         ]
 
-        text_processed, span_map = process(text, modifiers)
+        processed_text, span_map = process(text, modifiers)
 
-        self.assertEqual( text_processed, ' YYY YYY YYY YYY ' )
+        self.assertEqual( processed_text, ' YYY YYY YYY YYY ' )
         self.assertEqual( span_map, ref_span_map )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
         self.assertEqual( text_decorated, ' 000 111 222 333 ' )
-        self.assertEqual( text_processed_decorated, ' 000 111 222 333 ' )
+        self.assertEqual( decorated_processed_text, ' 000 111 222 333 ' )
 
     def test_chain_2(self):
         text = ' AAA BBB CCC DDD '
@@ -50,14 +50,14 @@ class ChainModifierTestCase(TestCase):
             ((9, 12), (17, 23))
         ]
 
-        text_processed, span_map = process(text, modifiers)
+        processed_text, span_map = process(text, modifiers)
 
-        self.assertEqual( text_processed, ' QQQQQQQ QQQQQQQ XXXXXX DDD ' )
+        self.assertEqual( processed_text, ' QQQQQQQ QQQQQQQ XXXXXX DDD ' )
         self.assertEqual( span_map, ref_span_map )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
-        self.assertEqual( text_processed_decorated, ' 0000000 1111111 222222 DDD ' )
+        self.assertEqual( decorated_processed_text, ' 0000000 1111111 222222 DDD ' )
         self.assertEqual( text_decorated, ' 000 111 222 DDD ' )
 
     def test_chain_3(self):
@@ -68,15 +68,15 @@ class ChainModifierTestCase(TestCase):
             ( r'(BB)',  { 1: 'DD' } )
         ]
 
-        text_processed, span_map = process(text, modifiers)
+        processed_text, span_map = process(text, modifiers)
 
-        self.assertEqual( text_processed, 'DDZDD' )
+        self.assertEqual( processed_text, 'DDZDD' )
         self.assertEqual( span_map, [ ((0, 1), (0, 2)), ((2, 3), (3, 5)) ] )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
         self.assertEqual( text_decorated, '0Z1' )
-        self.assertEqual( text_processed_decorated, '00Z11' )
+        self.assertEqual( decorated_processed_text, '00Z11' )
 
     def test_chain_4(self):
         text = ' AAA '
@@ -86,15 +86,15 @@ class ChainModifierTestCase(TestCase):
             ( r'(BBBBB)',  { 1: 'CC' } ),
         ]
 
-        text_processed, span_map = process(text, modifiers)
+        processed_text, span_map = process(text, modifiers)
 
-        self.assertEqual( text_processed, ' CC ' )
+        self.assertEqual( processed_text, ' CC ' )
         self.assertEqual( span_map, [ ((1, 4), (1, 3)) ] )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
         self.assertEqual( text_decorated, ' 000 ' )
-        self.assertEqual( text_processed_decorated, ' 00 ' )
+        self.assertEqual( decorated_processed_text, ' 00 ' )
 
     def test_chain_5(self):
         text = ' AAA D '
@@ -105,15 +105,15 @@ class ChainModifierTestCase(TestCase):
             ( r'(EE)',  { 1: 'FFFF' } ),
         ]
 
-        text_processed, span_map = process(text, modifiers)
+        processed_text, span_map = process(text, modifiers)
 
-        self.assertEqual( text_processed, ' CC FFFF ' )
+        self.assertEqual( processed_text, ' CC FFFF ' )
         self.assertEqual( span_map, [ ((1, 4), (1, 3)), ((5, 6), (4, 8)) ] )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
         self.assertEqual( text_decorated, ' 000 1 ' )
-        self.assertEqual( text_processed_decorated, ' 00 1111 ' )
+        self.assertEqual( decorated_processed_text, ' 00 1111 ' )
 
 
     def test_chain_6(self):
@@ -125,16 +125,19 @@ class ChainModifierTestCase(TestCase):
             ( r'(EE)',  { 1: 'FFFF' } ),
         ]
 
-        text_processed, span_map = process(text, modifiers)
+        processed_text, span_map = process(text, modifiers)
 
-        self.assertEqual( text_processed, ' CC FFFF CC FFFF ' )
+        self.assertEqual( processed_text, ' CC FFFF CC FFFF ' )
         self.assertEqual( span_map, [ ((1, 4), (1, 3)), ((5, 6), (4, 8)), ((7, 10), (9, 11)), ((11, 12), (12, 16)) ] )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
         self.assertEqual( text_decorated, ' 000 1 222 3 ' )
-        self.assertEqual( text_processed_decorated, ' 00 1111 22 3333 ' )
+        self.assertEqual( decorated_processed_text, ' 00 1111 22 3333 ' )
 
 
 if __name__ == '__main__':
-    main()
+    tc = ChainModifierTestCase()
+    tc.test_chain_2()
+    #tc.test_chain_6()
+    #main()

--- a/tests/test_intersecting_modifiers.py
+++ b/tests/test_intersecting_modifiers.py
@@ -15,15 +15,15 @@ class IntersectingModifierTestCase(TestCase):
             ( r'(C BBBBB C)',  { 1: 'DD' } ),
         ]
 
-        text_processed, span_map = process(text, modifiers)
+        processed_text, span_map = process(text, modifiers)
 
-        self.assertEqual( text_processed, 'DD' )
+        self.assertEqual( processed_text, 'DD' )
         self.assertEqual( span_map, [ ((0, 7), (0, 2)) ] )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
         self.assertEqual( text_decorated, '0000000' )
-        self.assertEqual( text_processed_decorated, '00' )
+        self.assertEqual( decorated_processed_text, '00' )
 
     def test_intersection_2(self):
         text = 'C AAA C'
@@ -33,15 +33,15 @@ class IntersectingModifierTestCase(TestCase):
             ( r'(C BBBBB)',  { 1: 'DD' } ),
         ]
 
-        text_processed, span_map = process(text, modifiers)
+        processed_text, span_map = process(text, modifiers)
 
-        self.assertEqual( text_processed, 'DD C' )
+        self.assertEqual( processed_text, 'DD C' )
         self.assertEqual( span_map, [ ((0, 5), (0, 2)) ] )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
         self.assertEqual( text_decorated, '00000 C' )
-        self.assertEqual( text_processed_decorated, '00 C' )
+        self.assertEqual( decorated_processed_text, '00 C' )
 
     def test_intersection_3(self):
         text = 'C AAA C'
@@ -51,15 +51,15 @@ class IntersectingModifierTestCase(TestCase):
             ( r'(BBBBB C)',  { 1: 'DD' } ),
         ]
 
-        text_processed, span_map = process(text, modifiers)
+        processed_text, span_map = process(text, modifiers)
 
-        self.assertEqual( text_processed, 'C DD' )
+        self.assertEqual( processed_text, 'C DD' )
         self.assertEqual( span_map, [ ((2, 7), (2, 4)) ] )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
         self.assertEqual( text_decorated, 'C 00000' )
-        self.assertEqual( text_processed_decorated, 'C 00' )
+        self.assertEqual( decorated_processed_text, 'C 00' )
 
     def test_intersection_4(self):
         text = 'C AAA C'
@@ -69,15 +69,15 @@ class IntersectingModifierTestCase(TestCase):
             ( r'(BBEBB)',  { 1: 'DD' } ),
         ]
 
-        text_processed, span_map = process(text, modifiers)
+        processed_text, span_map = process(text, modifiers)
 
-        self.assertEqual( text_processed, 'C DD C' )
+        self.assertEqual( processed_text, 'C DD C' )
         self.assertEqual( span_map, [ ((2, 5), (2, 4)) ] )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
         self.assertEqual( text_decorated, 'C 000 C' )
-        self.assertEqual( text_processed_decorated, 'C 00 C' )
+        self.assertEqual( decorated_processed_text, 'C 00 C' )
 
     def test_intersection_5(self):
         text = ' C AAA C '
@@ -88,15 +88,15 @@ class IntersectingModifierTestCase(TestCase):
             ( r'(C D)D',  { 1: 'FF' } ),
         ]
 
-        text_processed, span_map = process(text, modifiers)
+        processed_text, span_map = process(text, modifiers)
 
-        self.assertEqual( text_processed, ' FFD C ' )
+        self.assertEqual( processed_text, ' FFD C ' )
         self.assertEqual( span_map, [ ((1, 6), (1, 4)) ] )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
         self.assertEqual( text_decorated, ' 00000 C ' )
-        self.assertEqual( text_processed_decorated, ' 000 C ' )
+        self.assertEqual( decorated_processed_text, ' 000 C ' )
 
     def test_intersection_6(self):
         modifiers = [
@@ -106,14 +106,14 @@ class IntersectingModifierTestCase(TestCase):
 
         text = ' AAAB'
 
-        text_processed, span_map = process(text, modifiers)
-        self.assertEqual( text_processed, ' CCC CCCB' )
+        processed_text, span_map = process(text, modifiers)
+        self.assertEqual( processed_text, ' CCC CCCB' )
         self.assertEqual( span_map, [((1, 5), (1, 9))] )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
         self.assertEqual( text_decorated, ' 0000' )
-        self.assertEqual( text_processed_decorated, ' 00000000' )
+        self.assertEqual( decorated_processed_text, ' 00000000' )
 
 
     def test_intersection_7(self):
@@ -124,14 +124,14 @@ class IntersectingModifierTestCase(TestCase):
 
         text = 'BAAA '
 
-        text_processed, span_map = process(text, modifiers)
-        self.assertEqual( text_processed, 'BCCC CCC ' )
+        processed_text, span_map = process(text, modifiers)
+        self.assertEqual( processed_text, 'BCCC CCC ' )
         self.assertEqual( span_map, [((0, 4), (0, 8))] )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
         self.assertEqual( text_decorated, '0000 ' )
-        self.assertEqual( text_processed_decorated, '00000000 ' )
+        self.assertEqual( decorated_processed_text, '00000000 ' )
 
     def test_multiple_intersections_1(self):
         text = ' C AAA C D '
@@ -142,15 +142,15 @@ class IntersectingModifierTestCase(TestCase):
             ( r'(HJK)G',  { 1: 'FF' } ),
         ]
 
-        text_processed, span_map = process(text, modifiers)
+        processed_text, span_map = process(text, modifiers)
 
-        self.assertEqual( text_processed, 'FFG DD ' )
+        self.assertEqual( processed_text, 'FFG DD ' )
         self.assertEqual( span_map, [ ((0, 8), (0, 3)), ((9, 10), (4, 6)) ] )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
         self.assertEqual( text_decorated, '00000000 1 ' )
-        self.assertEqual( text_processed_decorated, '000 11 ' )
+        self.assertEqual( decorated_processed_text, '000 11 ' )
 
 
     def test_new(self):
@@ -161,16 +161,15 @@ class IntersectingModifierTestCase(TestCase):
 
         text = ' etc.'
                 
-        text_processed, span_map = process(text, modifiers)
+        processed_text, span_map = process(text, modifiers)
 
-        self.assertEqual( text_processed, ' et cetera.' )
-        self.assertEqual( span_map, [ ((1, 4), (1, 10)) ] )
+        self.assertEqual( processed_text, ' et cetera.' )
+        self.assertEqual( span_map, [ ((1, 5), (1, 11)) ] )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
-
-        self.assertEqual( text_decorated, ' 000.' )
-        self.assertEqual( text_processed_decorated, ' 000000000.' )
+        self.assertEqual( text_decorated, ' 0000' )
+        self.assertEqual( decorated_processed_text, ' 0000000000' )
 
 
 

--- a/tests/test_intersecting_modifiers.py
+++ b/tests/test_intersecting_modifiers.py
@@ -98,6 +98,23 @@ class IntersectingModifierTestCase(TestCase):
         self.assertEqual( text_decorated, ' 00000 C ' )
         self.assertEqual( text_processed_decorated, ' 000 C ' )
 
+    def test_intersection_6(self):
+        modifiers = [
+            ( r' (AAA)B',  { 1: 'CCC CCC'} ),
+            ( r'([^ ]+)',  { 1: lambda x: x } ),
+        ]
+
+        text = ' AAAB'
+
+        text_processed, span_map = process(text, modifiers)
+        self.assertEqual( text_processed, ' CCC CCCB' )
+        self.assertEqual( span_map, [((1, 4), (1, 8)), ((4, 5), (8, 9))] )
+
+        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+
+        self.assertEqual( text_decorated, '00001' )
+        self.assertEqual( text_processed_decorated, '0000000001' )
+
     def test_multiple_intersections_1(self):
         text = ' C AAA C D '
 
@@ -118,4 +135,7 @@ class IntersectingModifierTestCase(TestCase):
         self.assertEqual( text_processed_decorated, '000 11 ' )
 
 if __name__ == '__main__':
-    main()
+    tc = IntersectingModifierTestCase()
+    tc.test_intersection_6()
+
+    #main()

--- a/tests/test_intersecting_modifiers.py
+++ b/tests/test_intersecting_modifiers.py
@@ -174,7 +174,4 @@ class IntersectingModifierTestCase(TestCase):
 
 
 if __name__ == '__main__':
-    tc = IntersectingModifierTestCase()
-    tc.test_new()
-
-    #main()
+    main()

--- a/tests/test_intersecting_modifiers.py
+++ b/tests/test_intersecting_modifiers.py
@@ -101,19 +101,37 @@ class IntersectingModifierTestCase(TestCase):
     def test_intersection_6(self):
         modifiers = [
             ( r' (AAA)B',  { 1: 'CCC CCC'} ),
-            ( r'([^ ]+)',  { 1: lambda x: x } ),
+            ( r'(CCCB)',  { 1: lambda x: x } ),
         ]
 
         text = ' AAAB'
 
         text_processed, span_map = process(text, modifiers)
         self.assertEqual( text_processed, ' CCC CCCB' )
-        self.assertEqual( span_map, [((1, 4), (1, 8)), ((4, 5), (8, 9))] )
+        self.assertEqual( span_map, [((1, 5), (1, 9))] )
 
         text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
 
-        self.assertEqual( text_decorated, '00001' )
-        self.assertEqual( text_processed_decorated, '0000000001' )
+        self.assertEqual( text_decorated, ' 0000' )
+        self.assertEqual( text_processed_decorated, ' 00000000' )
+
+
+    def test_intersection_7(self):
+        modifiers = [
+            ( r'B(AAA) ',  { 1: 'CCC CCC'} ),
+            ( r'(BCCC)',  { 1: lambda x: x } ),
+        ]
+
+        text = 'BAAA '
+
+        text_processed, span_map = process(text, modifiers)
+        self.assertEqual( text_processed, 'BCCC CCC ' )
+        self.assertEqual( span_map, [((0, 4), (0, 8))] )
+
+        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+
+        self.assertEqual( text_decorated, '0000 ' )
+        self.assertEqual( text_processed_decorated, '00000000 ' )
 
     def test_multiple_intersections_1(self):
         text = ' C AAA C D '
@@ -134,8 +152,30 @@ class IntersectingModifierTestCase(TestCase):
         self.assertEqual( text_decorated, '00000000 1 ' )
         self.assertEqual( text_processed_decorated, '000 11 ' )
 
+
+    def test_new(self):
+        modifiers = [
+            ( r' (etc)\.',  { 1: 'et cetera'} ),
+            ( r'([^ ]+)',  { 1: lambda x: x } ),
+        ]
+
+        text = ' etc.'
+                
+        text_processed, span_map = process(text, modifiers)
+
+        self.assertEqual( text_processed, ' et cetera.' )
+        self.assertEqual( span_map, [ ((1, 4), (1, 10)) ] )
+
+        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+
+
+        self.assertEqual( text_decorated, ' 000.' )
+        self.assertEqual( text_processed_decorated, ' 000000000.' )
+
+
+
 if __name__ == '__main__':
     tc = IntersectingModifierTestCase()
-    tc.test_intersection_6()
+    tc.test_new()
 
     #main()

--- a/tests/test_intersecting_modifiers.py
+++ b/tests/test_intersecting_modifiers.py
@@ -160,7 +160,7 @@ class IntersectingModifierTestCase(TestCase):
         ]
 
         text = ' etc.'
-                
+
         processed_text, span_map = process(text, modifiers)
 
         self.assertEqual( processed_text, ' et cetera.' )

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -60,83 +60,83 @@ class OtherTestCase(TestCase):
 
     def test_0(self):
         text = str(self.text_0)
-        text_processed, span_map = process(text, self.modifiers_0)
-        self.assertEqual( text_processed, ' ZZZ YYY XXX WWW ' )
+        processed_text, span_map = process(text, self.modifiers_0)
+        self.assertEqual( processed_text, ' ZZZ YYY XXX WWW ' )
         self.assertEqual( span_map, self.span_map )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
         self.assertEqual( text_decorated, ' 000 111 222 333 ' )
-        self.assertEqual( text_processed_decorated, ' 000 111 222 333 ' )
+        self.assertEqual( decorated_processed_text, ' 000 111 222 333 ' )
 
     def test_1(self):
         text = str(self.text_1)
-        text_processed, span_map = process(text, self.modifiers_0)
-        self.assertEqual( text_processed, ' ZZZ YYY ZZZ YYY ' )
+        processed_text, span_map = process(text, self.modifiers_0)
+        self.assertEqual( processed_text, ' ZZZ YYY ZZZ YYY ' )
         self.assertEqual( span_map, self.span_map )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
         self.assertEqual( text_decorated, ' 000 111 222 333 ' )
-        self.assertEqual( text_processed_decorated, ' 000 111 222 333 ' )
+        self.assertEqual( decorated_processed_text, ' 000 111 222 333 ' )
 
     def test_2a(self):
         text = str(self.text_1)
-        text_processed, span_map = process(text, self.modifiers_1)
+        processed_text, span_map = process(text, self.modifiers_1)
 
-        self.assertEqual( text_processed, ' BBB BBB BBB BBB ' )
+        self.assertEqual( processed_text, ' BBB BBB BBB BBB ' )
         self.assertEqual( span_map, self.span_map_1_1 )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
         self.assertEqual( text_decorated, ' 000 BBB 111 BBB ' )
-        self.assertEqual( text_processed_decorated, ' 000 BBB 111 BBB ' )
+        self.assertEqual( decorated_processed_text, ' 000 BBB 111 BBB ' )
 
     def test_2b(self):
         text = str(self.text_3)
-        text_processed, span_map = process(text, self.modifiers_1)
+        processed_text, span_map = process(text, self.modifiers_1)
 
-        self.assertEqual( text_processed, ' BBB BBB BBB BBB ' )
+        self.assertEqual( processed_text, ' BBB BBB BBB BBB ' )
         self.assertEqual( span_map, self.span_map )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
         self.assertEqual( text_decorated, ' 000 111 222 333 ' )
-        self.assertEqual( text_processed_decorated, ' 000 111 222 333 ' )
+        self.assertEqual( decorated_processed_text, ' 000 111 222 333 ' )
 
     def test_3(self):
         text = str(self.text_2)
-        text_processed, span_map = process(text, self.modifiers_0)
-        self.assertEqual( text_processed, ' YYY ZZZ ZZZ YYY ' )
+        processed_text, span_map = process(text, self.modifiers_0)
+        self.assertEqual( processed_text, ' YYY ZZZ ZZZ YYY ' )
         self.assertEqual( span_map, self.span_map )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
         self.assertEqual( text_decorated, ' 000 111 222 333 ' )
-        self.assertEqual( text_processed_decorated, ' 000 111 222 333 ' )
+        self.assertEqual( decorated_processed_text, ' 000 111 222 333 ' )
 
     def test_4(self):
         text = str(self.text_0)
-        text_processed, span_map = process(text, self.modifiers_3)
-        self.assertEqual( text_processed, ' CCC CCC CCC CCC ' )
+        processed_text, span_map = process(text, self.modifiers_3)
+        self.assertEqual( processed_text, ' CCC CCC CCC CCC ' )
         self.assertEqual( span_map, self.span_map_2 )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
         self.assertEqual( text_decorated, ' 000 111 CCC 222 ' )
-        self.assertEqual( text_processed_decorated, ' 000 111 CCC 222 ' )
+        self.assertEqual( decorated_processed_text, ' 000 111 CCC 222 ' )
 
     def test_5(self):
         text = str(self.text_0)
-        text_processed, span_map = process(text, self.modifiers_4)
+        processed_text, span_map = process(text, self.modifiers_4)
 
-        self.assertEqual( text_processed, ' CCCC CCCC CCCC CCCC ' )
+        self.assertEqual( processed_text, ' CCCC CCCC CCCC CCCC ' )
         self.assertEqual( span_map, self.span_map_3 )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
         self.assertEqual( text_decorated, ' 000 111 222 333 ' )
-        self.assertEqual( text_processed_decorated, ' 0000 1111 2222 3333 ' )
+        self.assertEqual( decorated_processed_text, ' 0000 1111 2222 3333 ' )
 
 if __name__ == '__main__':
     main()

--- a/tests/test_single_modifier.py
+++ b/tests/test_single_modifier.py
@@ -13,9 +13,9 @@ class SingleModifierTestCase(TestCase):
         self.assertEqual( processed_text, 'CCDCCD' )
         self.assertEqual( span_map, [((0, 1), (0, 2)), ((1, 2), (2, 3)), ((2, 3), (3, 5)), ((3, 4), (5, 6))] )
 
-        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
+        decorated_text, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
-        self.assertEqual( text_decorated, '0123' )
+        self.assertEqual( decorated_text, '0123' )
         self.assertEqual( decorated_processed_text, '001223' )
 
     def test_b(self):
@@ -26,9 +26,9 @@ class SingleModifierTestCase(TestCase):
         self.assertEqual( processed_text, 'CDCD' )
         self.assertEqual( span_map, [((0, 2), (0, 1)), ((2, 3), (1, 2)), ((3, 5), (2, 3)), ((5, 6), (3, 4))] )
 
-        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
+        decorated_text, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
-        self.assertEqual( text_decorated, '001223' )
+        self.assertEqual( decorated_text, '001223' )
         self.assertEqual( decorated_processed_text, '0123' )
 
     def test_c(self):
@@ -39,9 +39,9 @@ class SingleModifierTestCase(TestCase):
         self.assertEqual( processed_text, 'CCDCCD' )
         self.assertEqual( span_map, [((0, 1), (0, 2)), ((1, 3), (2, 3)), ((3, 4), (3, 5)), ((4, 6), (5, 6))] )
 
-        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
+        decorated_text, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
-        self.assertEqual( text_decorated, '011233' )
+        self.assertEqual( decorated_text, '011233' )
         self.assertEqual( decorated_processed_text, '001223' )
 
     def test_new(self):
@@ -61,16 +61,16 @@ class SingleModifierTestCase(TestCase):
                 
         processed_text, span_map = process(text, modifiers)
 
-        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
+        decorated_text, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
         print (text)
-        print (text_decorated)
-        print (decorated_processed_text)
+        print (decorated_text)
         print (processed_text)
+        print (decorated_processed_text)
         print (span_map)
 
 if __name__ == '__main__':
-    tc = SingleModifierTestCase()
-    tc.test_new()
+    #tc = SingleModifierTestCase()
+    #tc.test_new()
 
-    #main()
+    main()

--- a/tests/test_single_modifier.py
+++ b/tests/test_single_modifier.py
@@ -44,33 +44,5 @@ class SingleModifierTestCase(TestCase):
         self.assertEqual( decorated_text, '011233' )
         self.assertEqual( decorated_processed_text, '001223' )
 
-    def test_new(self):
-        numbers = {5: 'five', 8: 'eight', 10: 'ten'}
-        orginal_numbers = {1: 'first', 2: 'second'}
-
-        modifiers = [
-            ( r'der (G\.) Be',  { 1: 'Graham'} ),
-            ( r' (&) ',  { 1: 'and'} ),
-            ( r' (etc)\.',  { 1: 'et cetera'} ),
-            ( r' ((\d+)((st)|(nd)|(rd)|(th))) ',  { 2: lambda x: orginal_numbers[int(x)], 3: '' } ),
-            ( r' (\d+) ',  { 1: lambda x: numbers[int(x)] } ),
-            ( r'([^ ]+)',  { 1: lambda x: x } ),
-        ]
-
-        text = 'Alexander G. Bell ate 10 apples & 8 cucumbers. The 1st apple was rotten, the 2nd was too, also the third, fourth etc.'
-
-        processed_text, span_map = process(text, modifiers)
-
-        decorated_text, decorated_processed_text = utils.decorate(text, processed_text, span_map)
-
-        print (text)
-        print (decorated_text)
-        print (processed_text)
-        print (decorated_processed_text)
-        print (span_map)
-
 if __name__ == '__main__':
-    #tc = SingleModifierTestCase()
-    #tc.test_new()
-
     main()

--- a/tests/test_single_modifier.py
+++ b/tests/test_single_modifier.py
@@ -58,7 +58,7 @@ class SingleModifierTestCase(TestCase):
         ]
 
         text = 'Alexander G. Bell ate 10 apples & 8 cucumbers. The 1st apple was rotten, the 2nd was too, also the third, fourth etc.'
-                
+
         processed_text, span_map = process(text, modifiers)
 
         decorated_text, decorated_processed_text = utils.decorate(text, processed_text, span_map)

--- a/tests/test_single_modifier.py
+++ b/tests/test_single_modifier.py
@@ -71,6 +71,6 @@ class SingleModifierTestCase(TestCase):
 
 if __name__ == '__main__':
     tc = SingleModifierTestCase()
-    tc.test_d()
+    tc.test_new()
 
     #main()

--- a/tests/test_single_modifier.py
+++ b/tests/test_single_modifier.py
@@ -9,40 +9,40 @@ class SingleModifierTestCase(TestCase):
         text = 'ABAB'
         modifiers = [ ( r'(A)(B)',  { 1: 'CC', 2:'D'} ) ]
 
-        text_processed, span_map = process(text, modifiers)
-        self.assertEqual( text_processed, 'CCDCCD' )
+        processed_text, span_map = process(text, modifiers)
+        self.assertEqual( processed_text, 'CCDCCD' )
         self.assertEqual( span_map, [((0, 1), (0, 2)), ((1, 2), (2, 3)), ((2, 3), (3, 5)), ((3, 4), (5, 6))] )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
         self.assertEqual( text_decorated, '0123' )
-        self.assertEqual( text_processed_decorated, '001223' )
+        self.assertEqual( decorated_processed_text, '001223' )
 
     def test_b(self):
         text = 'AABAAB'
         modifiers = [ ( r'(AA)(B)',  { 1: 'C', 2:'D'} ) ]
 
-        text_processed, span_map = process(text, modifiers)
-        self.assertEqual( text_processed, 'CDCD' )
+        processed_text, span_map = process(text, modifiers)
+        self.assertEqual( processed_text, 'CDCD' )
         self.assertEqual( span_map, [((0, 2), (0, 1)), ((2, 3), (1, 2)), ((3, 5), (2, 3)), ((5, 6), (3, 4))] )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
         self.assertEqual( text_decorated, '001223' )
-        self.assertEqual( text_processed_decorated, '0123' )
+        self.assertEqual( decorated_processed_text, '0123' )
 
     def test_c(self):
         text = 'ABBABB'
         modifiers = [ ( r'(A)(BB)',  { 1: 'CC', 2:'D'} ) ]
 
-        text_processed, span_map = process(text, modifiers)
-        self.assertEqual( text_processed, 'CCDCCD' )
+        processed_text, span_map = process(text, modifiers)
+        self.assertEqual( processed_text, 'CCDCCD' )
         self.assertEqual( span_map, [((0, 1), (0, 2)), ((1, 3), (2, 3)), ((3, 4), (3, 5)), ((4, 6), (5, 6))] )
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
         self.assertEqual( text_decorated, '011233' )
-        self.assertEqual( text_processed_decorated, '001223' )
+        self.assertEqual( decorated_processed_text, '001223' )
 
     def test_new(self):
         numbers = {5: 'five', 8: 'eight', 10: 'ten'}
@@ -59,14 +59,14 @@ class SingleModifierTestCase(TestCase):
 
         text = 'Alexander G. Bell ate 10 apples & 8 cucumbers. The 1st apple was rotten, the 2nd was too, also the third, fourth etc.'
                 
-        text_processed, span_map = process(text, modifiers)
+        processed_text, span_map = process(text, modifiers)
 
-        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+        text_decorated, decorated_processed_text = utils.decorate(text, processed_text, span_map)
 
         print (text)
         print (text_decorated)
-        print (text_processed_decorated)
-        print (text_processed)
+        print (decorated_processed_text)
+        print (processed_text)
         print (span_map)
 
 if __name__ == '__main__':

--- a/tests/test_single_modifier.py
+++ b/tests/test_single_modifier.py
@@ -44,5 +44,33 @@ class SingleModifierTestCase(TestCase):
         self.assertEqual( text_decorated, '011233' )
         self.assertEqual( text_processed_decorated, '001223' )
 
+    def test_new(self):
+        numbers = {5: 'five', 8: 'eight', 10: 'ten'}
+        orginal_numbers = {1: 'first', 2: 'second'}
+
+        modifiers = [
+            ( r'der (G\.) Be',  { 1: 'Graham'} ),
+            ( r' (&) ',  { 1: 'and'} ),
+            ( r' (etc)\.',  { 1: 'et cetera'} ),
+            ( r' ((\d+)((st)|(nd)|(rd)|(th))) ',  { 2: lambda x: orginal_numbers[int(x)], 3: '' } ),
+            ( r' (\d+) ',  { 1: lambda x: numbers[int(x)] } ),
+            ( r'([^ ]+)',  { 1: lambda x: x } ),
+        ]
+
+        text = 'Alexander G. Bell ate 10 apples & 8 cucumbers. The 1st apple was rotten, the 2nd was too, also the third, fourth etc.'
+                
+        text_processed, span_map = process(text, modifiers)
+
+        text_decorated, text_processed_decorated = utils.decorate(text, text_processed, span_map)
+
+        print (text)
+        print (text_decorated)
+        print (text_processed_decorated)
+        print (text_processed)
+        print (span_map)
+
 if __name__ == '__main__':
-    main()
+    tc = SingleModifierTestCase()
+    tc.test_d()
+
+    #main()


### PR DESCRIPTION
Fix another faulty span intersection scenario demonstrated in test_intersection_6 .
This floatet up when tried to add a pattern to README.md example that would additionally identify all non space sequences.